### PR TITLE
Moved RelationshipDelegatingFieldAccessorFactory to it's own file

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jConfiguration.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/config/Neo4jConfiguration.java
@@ -174,12 +174,12 @@ public class Neo4jConfiguration {
     }
 
     @Bean
-    public NodeDelegatingFieldAccessorFactory nodeDelegatingFieldAccessorFactory() throws Exception {
+    public DelegatingFieldAccessorFactory<NodeBacked> nodeDelegatingFieldAccessorFactory() throws Exception {
         return new NodeDelegatingFieldAccessorFactory(graphDatabaseContext());
     }
     
     @Bean
-    public RelationshipDelegatingFieldAccessorFactory relationshipDelegatingFieldAccessorFactory() throws Exception {
+    public DelegatingFieldAccessorFactory<RelationshipBacked> relationshipDelegatingFieldAccessorFactory() throws Exception {
         return new RelationshipDelegatingFieldAccessorFactory(graphDatabaseContext());
     }
 

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/node/NodeEntityState.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/node/NodeEntityState.java
@@ -21,7 +21,7 @@ import org.neo4j.graphdb.NotInTransactionException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.data.neo4j.core.NodeBacked;
 import org.springframework.data.neo4j.fieldaccess.DefaultEntityState;
-import org.springframework.data.neo4j.fieldaccess.NodeDelegatingFieldAccessorFactory;
+import org.springframework.data.neo4j.fieldaccess.DelegatingFieldAccessorFactory;
 import org.springframework.data.neo4j.support.GraphDatabaseContext;
 
 /**
@@ -32,7 +32,7 @@ public class NodeEntityState<ENTITY extends NodeBacked> extends DefaultEntitySta
 
     private final GraphDatabaseContext graphDatabaseContext;
 
-    public NodeEntityState(final Node underlyingState, final ENTITY entity, final Class<? extends ENTITY> type, final GraphDatabaseContext graphDatabaseContext, final NodeDelegatingFieldAccessorFactory nodeDelegatingFieldAccessorFactory) {
+    public NodeEntityState(final Node underlyingState, final ENTITY entity, final Class<? extends ENTITY> type, final GraphDatabaseContext graphDatabaseContext, final DelegatingFieldAccessorFactory<NodeBacked> nodeDelegatingFieldAccessorFactory) {
         super(underlyingState, entity, type, nodeDelegatingFieldAccessorFactory);
         this.graphDatabaseContext = graphDatabaseContext;
     }

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/node/NodeEntityStateFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/node/NodeEntityStateFactory.java
@@ -24,8 +24,8 @@ import org.neo4j.graphdb.Node;
 import org.springframework.data.neo4j.annotation.NodeEntity;
 import org.springframework.data.neo4j.core.EntityState;
 import org.springframework.data.neo4j.core.NodeBacked;
+import org.springframework.data.neo4j.fieldaccess.DelegatingFieldAccessorFactory;
 import org.springframework.data.neo4j.fieldaccess.DetachedEntityState;
-import org.springframework.data.neo4j.fieldaccess.NodeDelegatingFieldAccessorFactory;
 import org.springframework.data.neo4j.support.GraphDatabaseContext;
 
 public class NodeEntityStateFactory {
@@ -34,7 +34,7 @@ public class NodeEntityStateFactory {
 	
     private EntityManagerFactory entityManagerFactory;
 
-    private NodeDelegatingFieldAccessorFactory nodeDelegatingFieldAccessorFactory;
+    private DelegatingFieldAccessorFactory<NodeBacked> nodeDelegatingFieldAccessorFactory;
 
     private PartialNodeEntityState.PartialNodeDelegatingFieldAccessorFactory delegatingFieldAccessorFactory;
 
@@ -61,7 +61,7 @@ public class NodeEntityStateFactory {
     }
 
     public void setNodeDelegatingFieldAccessorFactory(
-    		NodeDelegatingFieldAccessorFactory nodeDelegatingFieldAccessorFactory) {
+    		DelegatingFieldAccessorFactory<NodeBacked> nodeDelegatingFieldAccessorFactory) {
 		this.nodeDelegatingFieldAccessorFactory = nodeDelegatingFieldAccessorFactory;
 	}
 	

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/relationship/RelationshipEntityState.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/relationship/RelationshipEntityState.java
@@ -32,7 +32,7 @@ public class RelationshipEntityState<ENTITY extends RelationshipBacked> extends 
 
     private final GraphDatabaseContext graphDatabaseContext;
     
-    public RelationshipEntityState(final Relationship underlyingState, final ENTITY entity, final Class<? extends ENTITY> type, final GraphDatabaseContext graphDatabaseContext, final RelationshipDelegatingFieldAccessorFactory delegatingFieldAccessorFactory) {
+    public RelationshipEntityState(final Relationship underlyingState, final ENTITY entity, final Class<? extends ENTITY> type, final GraphDatabaseContext graphDatabaseContext, final DelegatingFieldAccessorFactory<RelationshipBacked> delegatingFieldAccessorFactory) {
         super(underlyingState, entity, type, delegatingFieldAccessorFactory);
         this.graphDatabaseContext = graphDatabaseContext;
     }

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/relationship/RelationshipEntityStateFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/relationship/RelationshipEntityStateFactory.java
@@ -19,14 +19,14 @@ package org.springframework.data.neo4j.support.relationship;
 import org.neo4j.graphdb.Relationship;
 import org.springframework.data.neo4j.core.EntityState;
 import org.springframework.data.neo4j.core.RelationshipBacked;
-import org.springframework.data.neo4j.fieldaccess.RelationshipDelegatingFieldAccessorFactory;
+import org.springframework.data.neo4j.fieldaccess.DelegatingFieldAccessorFactory;
 import org.springframework.data.neo4j.support.GraphDatabaseContext;
 
 public class RelationshipEntityStateFactory {
 
 	private GraphDatabaseContext graphDatabaseContext;
 	
-    private RelationshipDelegatingFieldAccessorFactory relationshipDelegatingFieldAccessorFactory;
+    private DelegatingFieldAccessorFactory<RelationshipBacked> relationshipDelegatingFieldAccessorFactory;
 
     public EntityState<RelationshipBacked, Relationship> getEntityState(final RelationshipBacked entity) {
 		return new RelationshipEntityState<RelationshipBacked>(null,entity,entity.getClass(), graphDatabaseContext, relationshipDelegatingFieldAccessorFactory);
@@ -37,7 +37,7 @@ public class RelationshipEntityStateFactory {
 	}
 
 	public void setRelationshipDelegatingFieldAccessorFactory(
-			RelationshipDelegatingFieldAccessorFactory delegatingFieldAccessorFactory) {
+			DelegatingFieldAccessorFactory<RelationshipBacked> delegatingFieldAccessorFactory) {
 		this.relationshipDelegatingFieldAccessorFactory = delegatingFieldAccessorFactory;
 	}
 }


### PR DESCRIPTION
Regarding DATAGRAPH-99 I also created an own configuration bean for RelationshipDelegatingFieldAccessorFactory, which I pulled out from the RelationshipEntityState class into it's own file.
