### PR TITLE
Return an Iterable instead of a Set in OneToNRelationshipEntityFieldAccessor.getValue

### DIFF
--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/OneToNRelationshipEntityFieldAccessorFactory.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/fieldaccess/OneToNRelationshipEntityFieldAccessorFactory.java
@@ -16,20 +16,19 @@
 
 package org.springframework.data.neo4j.fieldaccess;
 
-import org.neo4j.graphdb.*;
+import static org.springframework.data.neo4j.support.DoReturn.doReturn;
+
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
-import org.springframework.data.neo4j.annotation.RelatedToVia;
 import org.springframework.data.neo4j.core.NodeBacked;
 import org.springframework.data.neo4j.core.RelationshipBacked;
 import org.springframework.data.neo4j.mapping.Neo4JPersistentProperty;
 import org.springframework.data.neo4j.mapping.RelationshipInfo;
+import org.springframework.data.neo4j.support.GraphBackedEntityIterableWrapper;
 import org.springframework.data.neo4j.support.GraphDatabaseContext;
-
-import java.lang.reflect.Field;
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.springframework.data.neo4j.support.DoReturn.doReturn;
 
 public class OneToNRelationshipEntityFieldAccessorFactory implements FieldAccessorFactory<NodeBacked> {
 
@@ -70,17 +69,11 @@ public class OneToNRelationshipEntityFieldAccessorFactory implements FieldAccess
 	    @Override
 	    public Object getValue(final NodeBacked entity) {
 	        checkUnderlyingNode(entity);
-	        final Set<RelationshipBacked> result = createEntitySetFromRelationships(entity);
-	        return doReturn(new ManagedFieldAccessorSet<NodeBacked, RelationshipBacked>(entity, result, property));
+	        return doReturn(iterableFrom(entity));
 	    }
 
-	    private Set<RelationshipBacked> createEntitySetFromRelationships(final NodeBacked entity) {
-	        final Set<RelationshipBacked> result = new HashSet<RelationshipBacked>();
-	        for (final Relationship rel : getStatesFromEntity(entity)) {
-	            final RelationshipBacked relationshipEntity = graphDatabaseContext.createEntityFromState(rel, relatedType);
-	            result.add(relationshipEntity);
-	        }
-	        return result;
+	    private Iterable<RelationshipBacked> iterableFrom(final NodeBacked entity) {
+	    	return GraphBackedEntityIterableWrapper.create(getStatesFromEntity(entity), (Class<RelationshipBacked>) relatedType, graphDatabaseContext);
 	    }
 
 	    @Override

--- a/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/GraphBackedEntityIterableWrapper.java
+++ b/spring-data-neo4j/src/main/java/org/springframework/data/neo4j/support/GraphBackedEntityIterableWrapper.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.neo4j.support;
+
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.helpers.collection.IterableWrapper;
+import org.springframework.data.neo4j.core.GraphBacked;
+
+/**
+ * Simple wrapper to create an Iterable over @NodeEntities or @RelationshipEntities from an iterable over Nodes or Relationships.
+ * Creates NodeEntities on the fly while iterating the Iterator from original iterable.
+ */
+public class GraphBackedEntityIterableWrapper<STATE extends PropertyContainer, ENTITY extends GraphBacked<STATE>> extends IterableWrapper<ENTITY, STATE> {
+    private final Class<ENTITY> targetType;
+    private final GraphDatabaseContext graphDatabaseContext;
+
+    public GraphBackedEntityIterableWrapper(Iterable<STATE> iterable, Class<ENTITY> targetType, final GraphDatabaseContext graphDatabaseContext) {
+        super(iterable);
+        this.targetType = targetType;
+        this.graphDatabaseContext = graphDatabaseContext;
+    }
+
+    @Override
+    protected ENTITY underlyingObjectToObject(STATE s) {
+        return graphDatabaseContext.createEntityFromState(s, targetType);
+    }
+    
+    public static <S extends PropertyContainer, E extends GraphBacked<S>> GraphBackedEntityIterableWrapper<S, E> create(
+    		Iterable<S> iterable, Class<E> targetType, final GraphDatabaseContext graphDatabaseContext) {
+    	return new GraphBackedEntityIterableWrapper<S, E>(iterable, targetType, graphDatabaseContext);
+    }
+}


### PR DESCRIPTION
Return an IterableWrapper in OneToNRelationshipEntityFieldAccessor.getValue instead of filling and returning a Set containing the result, since this is a readonly field accessor.
This should optimize the usage of:

``` java
@RelatedTo
Iterable<Foo> relatedNodes;
```
